### PR TITLE
fix(sourcekit-helper): use uri to file path

### DIFF
--- a/crates/sourcekit-helper/src/main.rs
+++ b/crates/sourcekit-helper/src/main.rs
@@ -119,7 +119,9 @@ fn register_for_changes(conn: &Conn, id: Id, params: OptionsChangedRequest) -> R
         return Ok(());
     }
 
-    let filepath = params.uri.path();
+    let filepath = params.uri
+        .to_file_path()
+        .map_err(|_| anyhow!("Invalid File URI: {:?}", params.uri))?;
     // tracing::info!("{filepath}");
     let root_path = state().lock().unwrap().root_path.clone();
     let uri = Url::from_directory_path(root_path).ok();

--- a/crates/sourcekit-helper/src/main.rs
+++ b/crates/sourcekit-helper/src/main.rs
@@ -254,7 +254,15 @@ fn main() -> Result<()> {
 
     let (conn, io_threads) = Connection::stdio();
     tracing::info!("Started");
-    conn.initialize(|params| initialize(&params).expect("Initialize"))?;
+    conn.initialize(|params|
+        match initialize(&params) {
+            Err(err) => {
+                tracing::error!("Failed to Initialize: ${}", err);
+                panic!("Initialization Failure: ${}", err);
+            },
+            Ok(build) => build
+        }
+    )?;
     tracing::info!("Initialized");
 
     for msg in &conn.receiver {


### PR DESCRIPTION
This fixes issues when trying to get compile arguments for file paths where there is a space. The URI is percent escaping but the files in the .compile file are not.