### PR TITLE
ref(editor): error on empty runners with configuration

### DIFF
--- a/lua/xbase/pickers.lua
+++ b/lua/xbase/pickers.lua
@@ -80,14 +80,29 @@ local get_selections = function(root, picker)
   for _, command in ipairs(commands) do
     for target, info in pairs(targets) do
       for _, configuration in ipairs(info.configurations) do
-        local devices = state.runners[info.platform]
-        if include_devices and command == C.Run and not (devices == nil or #devices == 0) then
+        local available_devices = state.runners[info.platform]
+        if include_devices and command == C.Run and not (available_devices == nil or #available_devices == 0) then
           local dvd = cfg.simctl[info.platform] or {}
 
+          local devices = {}
           if #dvd ~= 0 then
             devices = vim.tbl_filter(function(mem)
               return vim.tbl_contains(dvd, mem.name)
-            end, devices)
+            end, available_devices)
+            if #devices == 0 then
+              error(
+                string.format(
+                  "No runners available based on user config. config: %s, available: %s",
+                  table.concat(dvd, ","),
+                  table.concat(
+                    vim.tbl_map(function(d)
+                      return d.name
+                    end, available_devices),
+                    ","
+                  )
+                )
+              )
+            end
           end
 
           for _, device in ipairs(devices) do

--- a/vscode/xbase/commands.ts
+++ b/vscode/xbase/commands.ts
@@ -67,7 +67,7 @@ function getPickerItems(
     };
 
     if (runners) {
-      let platformRunners = runners;
+      let platformRunners: DeviceLookup[] = [];
       let platformDevices: string[];
 
       switch (platform) {
@@ -83,11 +83,15 @@ function getPickerItems(
       }
 
       if (platformDevices.length !== 0) {
-        platformRunners = platformRunners.filter(device => {
+        platformRunners = runners.filter(device => {
           return platformDevices.includes(device.name);
         });
+        if (platformRunners.length == 0) {
+          const configuredDevicesNames = platformDevices.join(", ");
+          const avaliableDeviceNames = runners.map(v => v.name).join(", ");
+          console.error(`No runners available based on user config. config: ${configuredDevicesNames}, available: ${avaliableDeviceNames}`);
+        }
       }
-      console.log(platformRunners);
 
       platformRunners.forEach(device => {
         console.log(device);


### PR DESCRIPTION
closes #181 

Although the goal was to just warn. An error is most appropriate in this case. On vscode, the experience is a bit different. Instead of throwing error,  console error is used. 