### PR TITLE
fix(editor): default runners are ignored on empty runners config

### DIFF
--- a/lua/xbase/pickers.lua
+++ b/lua/xbase/pickers.lua
@@ -103,6 +103,8 @@ local get_selections = function(root, picker)
                 )
               )
             end
+          else
+            devices = available_devices
           end
 
           for _, device in ipairs(devices) do

--- a/vscode/xbase/commands.ts
+++ b/vscode/xbase/commands.ts
@@ -91,6 +91,8 @@ function getPickerItems(
           const avaliableDeviceNames = runners.map(v => v.name).join(", ");
           console.error(`No runners available based on user config. config: ${configuredDevicesNames}, available: ${avaliableDeviceNames}`);
         }
+      } else {
+        platformRunners = runners;
       }
 
       platformRunners.forEach(device => {


### PR DESCRIPTION
caused by changes introduced in #182, noticed in #178.