### PR TITLE
ref(neovim): make build result in logs more obvious

### DIFF
--- a/syntax/xclog.vim
+++ b/syntax/xclog.vim
@@ -10,9 +10,9 @@ syn match   XbaseOperations   "\(Executing\|Compiling\|Generating\|Processing\|E
 syn match   XbaseSuccess      "\(Executed\|Compiled\|Generated\|Processed\|Emitted\|Copied\|Validated\|Signed\|Linked\|Installed\|Booted\|Launched\)"
 syn match   XbaseEntitlement  "Entitlement"
 syn region  XbaseScope        display oneline start='^\[' end='\]'
-syn match   XbaseLogError     "\(\[Error\]\)"
+syn match   XbaseLogError     "\(\[Error\]\|\[.*\].*failed\)"
 syn match   XbaseLogWarn      "\(\[Warning\]\)"
-syn match   XbaseLogSuccess   "\(\[Succeed\]\)"
+syn match   XbaseLogSuccess   "\(\[Succeed\]\|\[.*\] Built$\)"
 syn match   XbaseLogConnected "\(Connected\)"
 syn match   XbaseLogDone      "\(\[Done\]\)"
 syn match   XbaseLogPackage   "\(\[Package\]\)"

--- a/syntax/xclog.vim
+++ b/syntax/xclog.vim
@@ -10,9 +10,9 @@ syn match   XbaseOperations   "\(Executing\|Compiling\|Generating\|Processing\|E
 syn match   XbaseSuccess      "\(Executed\|Compiled\|Generated\|Processed\|Emitted\|Copied\|Validated\|Signed\|Linked\|Installed\|Booted\|Launched\)"
 syn match   XbaseEntitlement  "Entitlement"
 syn region  XbaseScope        display oneline start='^\[' end='\]'
-syn match   XbaseLogError     "\(\[Error\]\|\[.*\].*failed\)"
+syn match   XbaseLogError     "\c\(\[Error\]\|\[.*\].*failed\)"
 syn match   XbaseLogWarn      "\(\[Warning\]\)"
-syn match   XbaseLogSuccess   "\(\[Succeed\]\|\[.*\] Built$\)"
+syn match   XbaseLogSuccess   "\c\(\[Succeed\]\|\[.*\] Built$\)"
 syn match   XbaseLogConnected "\(Connected\)"
 syn match   XbaseLogDone      "\(\[Done\]\)"
 syn match   XbaseLogPackage   "\(\[Package\]\)"


### PR DESCRIPTION
Closes #189

@wojciech-kulik the output now for the build result as follows:

![image](https://user-images.githubusercontent.com/65782666/233817949-b5a1db91-0bb9-4b1e-8f6f-503a28ec595e.png)
