### PR TITLE
Fixed issue where adding a preferred device would break the run dialog

### DIFF
--- a/lua/xbase/state.lua
+++ b/lua/xbase/state.lua
@@ -37,7 +37,7 @@ M.devices = function(platform)
       return vim.tbl_contains(device_filter, mem.name)
     end, available_devices)
 
-    assert_devices(devices)
+    assert_devices(available_devices, devices, device_filter)
   end
 
   if #devices == 0 then


### PR DESCRIPTION
Before this pull I would get this error with the following config:

Error:

```
E5108: Error executing lua: ...s/saint/.local/share/nvim/lazy/xbase/lua/xbase/state.lua:14: attempt to get length of local 'devices' (a nil value)
stack traceback:
        ...s/saint/.local/share/nvim/lazy/xbase/lua/xbase/state.lua:14: in function 'assert_devices'
        ...s/saint/.local/share/nvim/lazy/xbase/lua/xbase/state.lua:41: in function 'devices'
        .../.local/share/nvim/lazy/xbase/lua/xbase/pickers/util.lua:90: in function 'iterate'
        .../.local/share/nvim/lazy/xbase/lua/xbase/pickers/util.lua:112: in function 'generate_entries'
        ...al/share/nvim/lazy/xbase/lua/xbase/pickers/telescope.lua:50: in function 'find'
        ...al/share/nvim/lazy/xbase/lua/xbase/pickers/telescope.lua:76: in function <...al/share/nvim/lazy/xbase/lua/xbase/pickers/telescope.lua:73>
Press ENTER or type command to continue
```

Config:
```
      require'xbase'.setup({
                sourcekit = {
                },
                simctl = {
                  iOS = {
                    "iPhone 14"
                  },
                  watchOS = {}, -- all available devices
                  tvOS = {}, -- all available devices
                },
      }) 
```

With this commit, it fixes the issue and works as expected, without error.
