### PR TITLE
ref(barebone): remove -use-frontend-parseable-output from .compile output

### DIFF
--- a/src/project/barebone.rs
+++ b/src/project/barebone.rs
@@ -109,7 +109,8 @@ impl ProjectCompile for BareboneProject {
             broadcast.warn("No compile command was generated!");
         }
 
-        let json = serde_json::to_vec_pretty(&xccommands)?;
+        let json = serde_json::to_string_pretty(&xccommands)?
+            .replace("-use-frontend-parseable-output", "");
         tokio::fs::write(root.join(".compile"), &json).await?;
 
         Ok(())


### PR DESCRIPTION
As noted in this issue #224 I was encountering the issue where this option would break my sourcekit-lsp. Manually removing this option from the generated `.compile` file seems to fix this for me. This does seem hacky however it works. If you have any advice on how to fix this better that would be awesome! 