### PR TITLE
fix(lua): incorrect keymap of closing buf in logger

### DIFF
--- a/lua/xbase/logger.lua
+++ b/lua/xbase/logger.lua
@@ -18,7 +18,7 @@ function M.setup()
   })
 
   util.bind(cfg.mappings, M.bufnr)
-  vim.keymap.set("n", "q", "close", { buffer = M.bufnr })
+  vim.keymap.set("n", "q", "<cmd>close<cr>", { buffer = M.bufnr })
 
   return M.bufnr
 end


### PR DESCRIPTION
The keymap in `logger.lua` for closing buffer is incorrect